### PR TITLE
getConfig() is no longer called inappropriately throughout the code -…

### DIFF
--- a/custom_node_modules/event_modules/eventTriggers.js
+++ b/custom_node_modules/event_modules/eventTriggers.js
@@ -6,9 +6,6 @@ const utils = require('../utility_modules/Utils.js')
 const printouts = require('../utility_modules/printouts')
 const config_helper = require('../utility_modules/config_helper')
 
-const config = config_helper.getConfig()
-const webdata = config_helper.getWebData()
-
 const script_directory = process.cwd() + '/scripts/'
 
 module.exports.ANALOG_WRITE_RESOLUTION = 255
@@ -161,6 +158,8 @@ module.exports._outputOff = _outputOff
  * @returns {boolean} true on success, false otherwise.
  */
 async function _emailWarn(schedule, state) {
+  const config = config_helper.getConfig()
+  const webdata = config_helper.getWebData()
   // If server says config isn't set up, pass
   if(state.warnState == false){
     return false;

--- a/custom_node_modules/utility_modules/Utils.js
+++ b/custom_node_modules/utility_modules/Utils.js
@@ -6,7 +6,6 @@ const dbcalls = require('./database_calls.js')
 const eventTriggers = require('../event_modules/EventTriggers')
 const fs = require('fs')
 const config_helper = require('../utility_modules/config_helper')
-const config = config_helper.getConfig()
 
 const CHART_INTERVAL = 24
 const INTERVALS = {
@@ -299,6 +298,7 @@ module.exports.eventTypeMapper = function scheduleTypeMapper(events, schedules){
 
 // Detects if there's a valid cookie.
 function cookieDetector(req) {
+  const config = config_helper.getConfig()
   try {
     jwt.verify(req.cookies.token, config.jwt_secret)
   } catch(e) {

--- a/custom_node_modules/utility_modules/config_helper.js
+++ b/custom_node_modules/utility_modules/config_helper.js
@@ -17,7 +17,7 @@ var config = undefined;
  * @param {string} config_location File location for the configuration file to load.
  * @returns the JSON version of the passed file.
  */
- const getConfig = function(config_location = CONFIG_LOCATION) {
+const getConfig = function(config_location = CONFIG_LOCATION) {
   if (config) return JSON.parse(JSON.stringify(config))
   config = JSON.parse(fs.readFileSync(config_location).toString())
   return JSON.parse(JSON.stringify(config))

--- a/custom_node_modules/utility_modules/database_calls.js
+++ b/custom_node_modules/utility_modules/database_calls.js
@@ -1,8 +1,7 @@
-var mysql = require('mysql');
-var config_helper = require('./config_helper');
+const mysql = require('mysql');
+const config_helper = require('./config_helper');
 const {simpleLogPrintout, simpleErrorPrintout} = require('./printouts')
 
-const config = config_helper.getConfig()
 
 var pool
 /**
@@ -10,8 +9,9 @@ var pool
  * or returns a previously created one.
  * @returns mysql connection pool.
  */
-const getPool = async function() {
+const getPool = function() {
   if (pool) return pool
+  let config = config_helper.getConfig()
   pool = mysql.createPool(config.database)
   return pool
 }

--- a/custom_node_modules/utility_modules/mappings.js
+++ b/custom_node_modules/utility_modules/mappings.js
@@ -12,9 +12,9 @@ var board = null;
  * @returns JSON pinout for the board listed in config.
  */
 module.exports.getBoardMapping = function getBoardMapping(){
-  var config = config_helper.getConfig()
   if(board == null) {
-    let board_mappings = JSON.parse(fs.readFileSync(BOARD_MAPPINGS_LOCATION).toString())    
+    const config = config_helper.getConfig()
+    const board_mappings = JSON.parse(fs.readFileSync(BOARD_MAPPINGS_LOCATION).toString())    
     board = board_mappings[config.board]  
   }
   return JSON.parse(JSON.stringify(board))

--- a/test/growth/custom_node_modules/utility_modules/Mappings.spec.js
+++ b/test/growth/custom_node_modules/utility_modules/Mappings.spec.js
@@ -76,6 +76,7 @@ describe('Mappings.js tests', () => {
         { outputPWM: 0, OUTPUT_PIN: 4 },
         { outputPWM: 1, OUTPUT_PIN: 5, PWM_PIN: 12 }
       ]
+      sinon.stub(config_helper, 'getConfig').returns({relay_toggle_prevention: true})
       sinon.stub(mappings,'getBoardMapping').returns(JSON.parse(JSON.stringify(standard_board_mappings_return)))
       sinon.stub(dbcalls, 'getEnabledOutputs').resolves(output_fixture)
       let actual = await mappings.getOutputMappings()

--- a/test/growth/custom_node_modules/utility_modules/config_helper.spec.js
+++ b/test/growth/custom_node_modules/utility_modules/config_helper.spec.js
@@ -21,10 +21,11 @@ describe('config_helper.js tests: ', () => {
     let config_fixture = {"test" : "test"}
     it('should set and return a parsed JSON object', () => {
       sinon.stub(JSON, 'parse').returns(config_fixture)
+      sinon.stub(fs, 'readFileSync').returns(Buffer.alloc(0))
       assert.deepEqual(config_helper.getConfig(), config_fixture)
     })
     it('should call fs.readFileSync() only once, returning the config from the initial call', () => {
-      let fs_stub = sinon.spy(fs, 'readFileSync')
+      let fs_stub = sinon.stub(fs, 'readFileSync').returns(Buffer.alloc(0))
       sinon.stub(JSON, 'parse').returns(config_fixture)
       config_helper.getConfig()
       assert.deepEqual(config_helper.getConfig(), config_fixture)
@@ -39,10 +40,11 @@ describe('config_helper.js tests: ', () => {
     let config_fixture = {"test" : "test"}
     it('should set and return a parsed JSON object', () => {
       sinon.stub(JSON, 'parse').returns(config_fixture)
+      sinon.stub(fs, 'readFileSync').returns(Buffer.alloc(0))
       assert.deepEqual(config_helper.getWebData(), config_fixture)
     })
     it('should call JSON.parse() only once, returning the config from the initial call', () => {
-      let fs_stub = sinon.stub(fs, 'readFileSync').returns("")
+      let fs_stub = sinon.stub(fs, 'readFileSync').returns(Buffer.alloc(0))
       sinon.stub(JSON, 'parse').returns(config_fixture)
       config_helper.getWebData()
       assert.deepEqual(config_helper.getWebData(), config_fixture)

--- a/test/growth/custom_node_modules/utility_modules/database_calls.spec.js
+++ b/test/growth/custom_node_modules/utility_modules/database_calls.spec.js
@@ -4,8 +4,11 @@ const expect = chai.expect;
 const assert = chai.assert;
 const mysql = require("mysql")
 
-var dbcalls
+let dbcalls
+let config_helper
 function resetModules() {
+  delete require.cache[require.resolve("../../../../custom_node_modules/utility_modules/config_helper")]
+  config_helper = require("../../../../custom_node_modules/utility_modules/config_helper")
   delete require.cache[require.resolve('../../../../custom_node_modules/utility_modules/database_calls')];
   dbcalls = require('../../../../custom_node_modules/utility_modules/database_calls');
 }
@@ -15,33 +18,25 @@ describe('database_calls.js tests', () => {
     beforeEach(() => {
       resetModules()
     })
-    it('should create and return a database pool object', async () => {
-      expected_keys = [
-        '_events',
-        '_eventsCount',
-        '_maxListeners',
-        'config',
-        '_acquiringConnections',
-        '_allConnections',
-        '_freeConnections',
-        '_connectionQueue',
-        '_closed'
-      ]
-      let actual = Object.keys(await dbcalls.getPool())
-      expect(expected_keys).to.be.deep.equal(actual)
+    it('should create and return a database pool object', () => {
+      sinon.stub(config_helper, 'getConfig').returns({database:null})
+      let mysql_stub = sinon.stub(mysql, 'createPool').returns('test')
+      let res = dbcalls.getPool()
+      assert.deepEqual(res, 'test')
+      sinon.assert.calledOnce(mysql_stub)
     })
-    it('should call createPool() only once, returning the pool from the initial call', async () => {
-      let mysql_stub = sinon.stub(mysql, 'createPool').returns("test")
-      await dbcalls.getPool()
-      assert.deepEqual(await dbcalls.getPool(), "test")
+    
+    it('should call createPool() only once', () => {
+      sinon.stub(config_helper, 'getConfig').returns({database:null})
+      let mysql_stub = sinon.stub(mysql, 'createPool').returns('test')
+      dbcalls.getPool()
+      let res = dbcalls.getPool()
+      assert.deepEqual(res, 'test')
       sinon.assert.calledOnce(mysql_stub)
     })
   })
 
   describe('testConnectivity() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = { data : 1 }
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -64,9 +59,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('addNewEvent() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -89,9 +81,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('addNewOutput() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -114,9 +103,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('addNewOutputType() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -139,9 +125,6 @@ describe('database_calls.js tests', () => {
   })
   
   describe('addNewSchedule() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -164,9 +147,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('addNewScheduleType() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -189,9 +169,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('addNewSensor() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -214,9 +191,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('addNewSensorType() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -239,9 +213,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('addNewUser() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -264,9 +235,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('addSensorReading() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -289,9 +257,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('disableSchedule() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -314,9 +279,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('disableOutputType() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -339,9 +301,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('disableOutput() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -364,9 +323,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('disableSensor() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -389,9 +345,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getAllEvents() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -414,9 +367,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getAllOutputs() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -439,9 +389,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getAllOutputTypes() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -464,9 +411,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getAllSchedules() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -489,9 +433,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getAllScheduleTypes() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -514,9 +455,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getAllSensors() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -539,9 +477,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getAllSensorTypes() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -564,9 +499,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getAllUsers() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -589,9 +521,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getEnabledEvents() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -614,9 +543,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getEnabledLiveSchedules() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -639,9 +565,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getEnabledOutputs() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -664,9 +587,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getEnabledOrderedOutputs() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -689,9 +609,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getEnabledOutputTypes() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -714,9 +631,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getEnabledSchedules() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -739,9 +653,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getEnabledScheduleTypes() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -764,9 +675,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getEnabledSensors() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -789,9 +697,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getEnabledSensorTypes() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -814,9 +719,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getEnabledSensorTypes() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -839,9 +741,6 @@ describe('database_calls.js tests', () => {
   })
   
   describe('getScheduleByID() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -864,9 +763,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getSensorDataByType() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -889,9 +785,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getSensorLastReadings() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -914,9 +807,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getSensorLastReadingsByHours() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -939,9 +829,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('getUser() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -964,9 +851,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('logScheduledEvent() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -989,9 +873,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('updateSensorAddress() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -1014,9 +895,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('updateOutputType() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -1039,9 +917,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('updateOutput() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            
@@ -1064,9 +939,6 @@ describe('database_calls.js tests', () => {
   })
 
   describe('updateSensor() tests', () => {
-    beforeEach(() => {
-      resetModules()
-    })
     it('should resolve with results', async () => {
       let test_result = [{ data : 1 }]
       const connStub = { query: sinon.stub().yields(undefined, test_result), release: sinon.stub() };            


### PR DESCRIPTION
… originally might've caused problems if tests were called without a valid config, but I thiiiiiiiiink that's cleared up.