### PR TITLE
Camera enable/disable change.

### DIFF
--- a/api/images.js
+++ b/api/images.js
@@ -8,7 +8,7 @@ const utils = require('../custom_node_modules/utility_modules/utils')
 let config = config_helper.getConfig()
 
 router.get('/latest', auth, async function(req, res, next) {
-  if (config.camera.enable != true){
+  if (config.camera.image_api_enable != true){
     res.status(404).send()
   } else {
     try {
@@ -21,7 +21,7 @@ router.get('/latest', auth, async function(req, res, next) {
 })
 
 router.get('/take_image', auth, async function(req, res, next) {
-  if (config.camera.enable != true){
+  if (config.camera.image_api_enable != true){
     res.status(404).send()
   } else {
     try {

--- a/config/default_config.json
+++ b/config/default_config.json
@@ -24,6 +24,7 @@
       "start": null,
       "stop": null
     },
+    "image_api_enable": false,
     "image_directory": "./images",
     "image_width": 1920,
     "image_height": 1080,


### PR DESCRIPTION
Added a new entry in the configuration file for disabling/enabling the image api. Should enable users to have camera functionality without actually requiring images to be displayed on the website